### PR TITLE
Statically check exhaustivity of cases on types

### DIFF
--- a/py/foundation/entity.py
+++ b/py/foundation/entity.py
@@ -10,8 +10,9 @@ from foundation.protos import geometry_pb2
 from foundation.protos.doc import entity_pb2
 from foundation.protos.doc.entity_pb2 import Currency as Currency_pb2
 
-from .typing_utils import assert_exhaustive
 from .ocr import InputWord
+from .typing_utils import assert_exhaustive
+
 """ These are the built-in Entity types supported by Foundation. """
 PbEntityPayloadType = Union[entity_pb2.OcrWord, entity_pb2.Line,
                             entity_pb2.Paragraph, entity_pb2.TableCell,

--- a/py/foundation/entity.py
+++ b/py/foundation/entity.py
@@ -10,6 +10,7 @@ from foundation.protos import geometry_pb2
 from foundation.protos.doc import entity_pb2
 from foundation.protos.doc.entity_pb2 import Currency as Currency_pb2
 
+from .typing_utils import assert_exhaustive
 from .ocr import InputWord
 """ These are the built-in Entity types supported by Foundation. """
 PbEntityPayloadType = Union[entity_pb2.OcrWord, entity_pb2.Line,
@@ -483,6 +484,4 @@ def proto_to_entity(
     raise ValueError(
         f'No implementation found for GenericEntity type "{custom_type}".')
 
-  # This is a protocol decoding error, probably missing an if statement
-  # in this function.
-  raise AssertionError(f'Unhandled message type: {payload_type}')
+  assert_exhaustive(payload_type)

--- a/py/foundation/typing_utils.py
+++ b/py/foundation/typing_utils.py
@@ -1,0 +1,23 @@
+from typing import NoReturn
+
+
+def assert_exhaustive(x: NoReturn) -> NoReturn:
+  """Takes advantage of mypy's type narrowing to statically check exhaustivity.
+
+  Use this to ensure all type variants of a Union/Enum/etc are cased.
+
+  See: https://github.com/python/mypy/issues/5818
+
+  Example:
+    MyUnion = Union[int, str, bytes]
+
+    def my_function(x: MyUnion) -> None:
+      if isinstance(x, int):
+        ...
+      elif isinstance(x, str):
+        ...
+      # oh no, we forgot to put in a case for bytes!
+      else:
+        assert_exhaustive(x)  # mypy will catch this statically
+  """
+  raise AssertionError(f'Unhandled type: {type(x).__name__}')


### PR DESCRIPTION
Catches non-exhaustive if-statements statically using mypy. This is useful especially for type unions like `PbEntityPayloadType`, with many many variants, to avoid unhandled message types.

Mypy will emit an error like `py/foundation/entity.py:487: error: Argument 1 to "assert_exhaustive" has incompatible type "Literal['cluster']"; expected "NoReturn"`, which tells you 1) the line where you should add an extra case and 2) the type you forgot to case on.