### PR TITLE
Every entity has a BBox

### DIFF
--- a/protos/foundation/protos/doc/entity.proto
+++ b/protos/foundation/protos/doc/entity.proto
@@ -2,11 +2,13 @@ syntax = "proto2";
 
 package doc;
 
+import "foundation/protos/geometry.proto";
 import "foundation/protos/ocr/types.proto";
 
+/* Union type holds one of these Entity variants. */
 message Entity {
 	oneof payload {
-		OcrWord ocr_word = 1;
+		Word word = 1;
 		Line line = 2;
 		Paragraph paragraph = 3;
 		TableCell table_cell = 4;
@@ -36,16 +38,20 @@ message GenericEntity {
 	// The 'type' field tells a decoder how to deserialize the 'data' field.
 	required string type = 1;
 	required bytes data = 2;
+	required geometry.BBox bbox = 3;
 }
 
-/* Corresponds to an OCR input word. */
-message OcrWord {
-	required ocr.InputWord word = 1;
+/* Corresponds to an OCR word. */
+message Word {
+	required string text = 1;
+	required geometry.BBox bbox = 2;
+	optional ocr.InputWord origin = 3;
 }
 
 /* A sequence of OCR words. */
 message Line {
-	repeated ocr.InputWord ocr_words = 1;
+	repeated Word words = 1;
+	required geometry.BBox bbox = 2;
 }
 
 /* A sequence of Lines.
@@ -54,6 +60,7 @@ message Line {
 */
 message Paragraph {
 	repeated Line lines = 1;
+	required geometry.BBox bbox = 2;
 }
 
 /* A Cell of a table.
@@ -62,11 +69,13 @@ message Paragraph {
 */
 message TableCell {
 	repeated Entity content = 1;
+	required geometry.BBox bbox = 2;
 }
 
 /* A Row is a sequence of table cells. */
 message TableRow {
 	repeated TableCell cells = 1;
+	required geometry.BBox bbox = 2;
 }
 
 /* A Table is a sequence of rows.
@@ -75,6 +84,7 @@ message TableRow {
 */
 message Table {
 	repeated TableRow rows = 1;
+	required geometry.BBox bbox = 2;
 }
 
 /* ----- Semantic types ----- */
@@ -87,13 +97,15 @@ message Table {
 	 words into multiple OCR rectangles.
  */
 message Token {
-	repeated ocr.InputWord span = 1;
+	repeated Word span = 1;
+	required geometry.BBox bbox = 2;
 }
 
 /* A Phrase is a sequence of Tokens, grouped into a useful semantic unit.
 */
 message Phrase {
 	repeated Token words = 1;
+	required geometry.BBox bbox = 2;
 }
 
 
@@ -109,45 +121,51 @@ message Phrase {
 */
 message Number {
 	required Token token = 1;
-	optional double value = 2;
+	required geometry.BBox bbox = 2;
+	optional double value = 3;
 }
 
 message Integer {
 	required Token token = 1;
-	optional int64 value = 2;
+	required geometry.BBox bbox = 2;
+	optional int64 value = 3;
 }
 
 message Date {
 	required Token token = 1;
+	required geometry.BBox bbox = 2;
 	// Let this value be an ISO8601 formatted date.
 	// TODO: we should settle on an appropriate denotation format here.
-	optional string value = 2;
+	optional string value = 3;
 }
 
 message Time {
 	required Token token = 1;
+	required geometry.BBox bbox = 2;
 	// Let this value be UNIX time in seconds from the epoch.
 	// TODO: we should settle on an appropriate denotation format here.
-	optional uint64 value = 2;
+	optional uint64 value = 3;
 }
 
 // TODO: do we want a Datetime type?
 
 message Currency {
 	required Token token = 1;
+	required geometry.BBox bbox = 2;
 	// Fixed-point representation for currency avoids float-rounding issues.
 	// TODO: we should settle on an appropriate denotation format here.
 	message FixedDecimal {
 		required int64 integer_part = 1;
 		required uint32 fractional_part = 2;
 	}
-	optional FixedDecimal value = 2;
+	optional FixedDecimal value = 3;
 	optional string units = 4;
 }
 
 message Name {
 	required Phrase name_parts = 1;
-	optional string value = 2;
+	required geometry.BBox bbox = 2;
+	optional string value = 3;
 }
 
 message Address {
@@ -155,8 +173,9 @@ message Address {
 	// This would distinguish an OCR Line from some other way of grouping Tokens together.
 	// TODO: is sequence of Phrase the right unit type here?
 	repeated Phrase lines = 1;
+	required geometry.BBox bbox = 2;
 	// TODO: we should settle on an appropriate denotation format here.
-	optional string value = 2;
+	optional string value = 3;
 }
 
 /* A Cluster associates a Phrase [a sequence of Tokens] with some semantic label.
@@ -166,6 +185,7 @@ message Address {
 message Cluster {
 	// TODO: is Phrase the right unit type here?
 	required Phrase token_span = 1;
-	optional string label = 2;
+	required geometry.BBox bbox = 2;
+	optional string label = 3;
 }
 

--- a/protos/foundation/protos/doc/entity.proto
+++ b/protos/foundation/protos/doc/entity.proto
@@ -14,14 +14,12 @@ message Entity {
 		TableCell table_cell = 4;
 		TableRow table_row = 5;
 		Table table = 6;
-		Token token = 7;
-		Phrase phrase = 8;
 		Number number = 9;
 		Integer integer = 10;
 		Date date = 11;
 		Time time = 12;
 		Currency currency = 13;
-		Name name = 14;
+		PersonName name = 14;
 		Address address = 15;
 		Cluster cluster = 16;
 		GenericEntity custom = 17;
@@ -89,26 +87,6 @@ message Table {
 
 /* ----- Semantic types ----- */
 
-/* A Token is a sequence of OCR words, grouped into a useful semantic unit.
-
-	 Tokens are a semantic type, e.g. a natural-language word like "fire truck".
-
-	 We may also want to handle OCR errors which split natural language
-	 words into multiple OCR rectangles.
- */
-message Token {
-	repeated Word span = 1;
-	required geometry.BBox bbox = 2;
-}
-
-/* A Phrase is a sequence of Tokens, grouped into a useful semantic unit.
-*/
-message Phrase {
-	repeated Token words = 1;
-	required geometry.BBox bbox = 2;
-}
-
-
 /* -------------------------------------------------------------------
 	 These are essentially NER types. It can be useful to distinguish a set of
 	 "first-class" types from some label class that a specific NER model might
@@ -120,19 +98,19 @@ message Phrase {
 /* A Number is a real-valued number.
 */
 message Number {
-	required Token token = 1;
+	repeated Word span = 1;
 	required geometry.BBox bbox = 2;
 	optional double value = 3;
 }
 
 message Integer {
-	required Token token = 1;
+	repeated Word span = 1;
 	required geometry.BBox bbox = 2;
 	optional int64 value = 3;
 }
 
 message Date {
-	required Token token = 1;
+	repeated Word span = 1;
 	required geometry.BBox bbox = 2;
 	// Let this value be an ISO8601 formatted date.
 	// TODO: we should settle on an appropriate denotation format here.
@@ -140,7 +118,7 @@ message Date {
 }
 
 message Time {
-	required Token token = 1;
+	repeated Word span = 1;
 	required geometry.BBox bbox = 2;
 	// Let this value be UNIX time in seconds from the epoch.
 	// TODO: we should settle on an appropriate denotation format here.
@@ -150,7 +128,7 @@ message Time {
 // TODO: do we want a Datetime type?
 
 message Currency {
-	required Token token = 1;
+	repeated Word span = 1;
 	required geometry.BBox bbox = 2;
 	// Fixed-point representation for currency avoids float-rounding issues.
 	// TODO: we should settle on an appropriate denotation format here.
@@ -162,17 +140,14 @@ message Currency {
 	optional string units = 4;
 }
 
-message Name {
-	required Phrase name_parts = 1;
+message PersonName {
+	repeated Line name_parts = 1;
 	required geometry.BBox bbox = 2;
 	optional string value = 3;
 }
 
 message Address {
-	// Grouping Phrases, each phrase a "line", into an Address message may be good.
-	// This would distinguish an OCR Line from some other way of grouping Tokens together.
-	// TODO: is sequence of Phrase the right unit type here?
-	repeated Phrase lines = 1;
+	repeated Line lines = 1;
 	required geometry.BBox bbox = 2;
 	// TODO: we should settle on an appropriate denotation format here.
 	optional string value = 3;
@@ -183,8 +158,7 @@ message Address {
 	 This type should be useful to NER-like models.
 */
 message Cluster {
-	// TODO: is Phrase the right unit type here?
-	required Phrase token_span = 1;
+	repeated Line span = 1;
 	required geometry.BBox bbox = 2;
 	optional string label = 3;
 }

--- a/py/foundation/entity.py
+++ b/py/foundation/entity.py
@@ -10,10 +10,11 @@ from foundation.protos import geometry_pb2
 from foundation.protos.doc import entity_pb2
 from foundation.protos.doc.entity_pb2 import Currency as Currency_pb2
 
+from .geometry import BBox
 from .ocr import InputWord
-from .typing_utils import assert_exhaustive
+from .typing_utils import assert_exhaustive, unwrap
 """ These are the built-in Entity types supported by Foundation. """
-PbEntityPayloadType = Union[entity_pb2.OcrWord, entity_pb2.Line,
+PbEntityPayloadType = Union[entity_pb2.Word, entity_pb2.Line,
                             entity_pb2.Paragraph, entity_pb2.TableCell,
                             entity_pb2.TableRow, entity_pb2.Table,
                             entity_pb2.Token, entity_pb2.Phrase,
@@ -51,6 +52,11 @@ class Entity(abc.ABC, Generic[E]):
 
   @property
   @abc.abstractmethod
+  def bbox(self) -> BBox:
+    ...
+
+  @property
+  @abc.abstractmethod
   def children(self) -> Iterable[E]:
     """Yields all sub-entities of this entity.
 
@@ -62,7 +68,7 @@ class Entity(abc.ABC, Generic[E]):
     """
     ...
 
-  def ocr_words(self) -> Iterable['OcrWordEntity']:
+  def ocr_words(self) -> Iterable['WordEntity']:
     """Yields all OcrWordEntity's among this entity's children.
 
     Can be seen as returning an iterator over the leaves of this
@@ -76,33 +82,34 @@ class Entity(abc.ABC, Generic[E]):
 
 
 @dataclass(frozen=True)
-class OcrWordEntity(Entity):
-  word: InputWord
-
-  @property
-  def origin(self) -> InputWord:
-    """Provenance data.
-
-    Returns the OCR InputWord corresponding to this Entity.
-    """
-    return self.word
+class WordEntity(Entity):
+  text: str
+  bbox: BBox
+  origin: Optional[InputWord] = None
 
   @staticmethod
-  def from_proto(msg: PbEntityPayloadType) -> 'OcrWordEntity':
-    assert isinstance(msg, entity_pb2.OcrWord)
-    return OcrWordEntity(InputWord.from_proto(msg.word))
+  def from_proto(msg: PbEntityPayloadType) -> 'WordEntity':
+    assert isinstance(msg, entity_pb2.Word)
+    text = msg.text
+    bbox = unwrap(BBox.from_proto(msg.bbox))  # TODO: what does None mean here?
+    input_word = None
+    if msg.HasField('origin'):
+      input_word = InputWord.from_proto(msg.origin)
+    return WordEntity(text, bbox, input_word)
 
-  def to_proto(self) -> entity_pb2.OcrWord:
-    msg = entity_pb2.OcrWord()
-    msg.word.CopyFrom(self.word.to_proto())
+  def to_proto(self) -> entity_pb2.Word:
+    msg = entity_pb2.Word(text=self.text,
+                          bbox=self.bbox.to_proto())
+    if self.origin is not None:
+      msg.origin.CopyFrom(self.origin.to_proto())
     return msg
 
   @property
   def children(self) -> Iterable[E]:
-    """ OcrWordEntity has no children. """
+    """ WordEntity has no children. """
     yield from []
 
-  def ocr_words(self) -> Iterable['OcrWordEntity']:
+  def ocr_words(self) -> Iterable['WordEntity']:
     """ Yields itself.
 
     This provides the base case for Entity.ocr_words.
@@ -112,23 +119,23 @@ class OcrWordEntity(Entity):
 
 @dataclass(frozen=True)
 class LineEntity(Entity):
-  _ocr_words: List[OcrWordEntity]
+  _ocr_words: List[WordEntity]
+  bbox: BBox
 
   @staticmethod
   def from_proto(msg: PbEntityPayloadType) -> 'LineEntity':
     assert isinstance(msg, entity_pb2.Line)
-    ocr_words = [OcrWordEntity(InputWord.from_proto(w)) for w in msg.ocr_words]
-    return LineEntity(ocr_words)
+    bbox = unwrap(BBox.from_proto(msg.bbox))
+    ocr_words = [WordEntity.from_proto(w) for w in msg.words]
+    return LineEntity(ocr_words, bbox)
 
   def to_proto(self) -> entity_pb2.Line:
-    msg = entity_pb2.Line()
-    for w in self._ocr_words:
-      input_word_msg = w.word.to_proto()
-      msg.ocr_words.append(input_word_msg)
+    msg = entity_pb2.Line(bbox=self.bbox.to_proto())
+    msg.words.extend(w.to_proto() for w in self._ocr_words)
     return msg
 
   @property
-  def children(self) -> Iterable[OcrWordEntity]:
+  def children(self) -> Iterable[WordEntity]:
     """ A LineEntity's children are its OCR words. """
     yield from self._ocr_words
 
@@ -136,15 +143,17 @@ class LineEntity(Entity):
 @dataclass(frozen=True)
 class ParagraphEntity(Entity):
   lines: List[LineEntity]
+  bbox: BBox
 
   @staticmethod
   def from_proto(msg: PbEntityPayloadType) -> 'ParagraphEntity':
     assert isinstance(msg, entity_pb2.Paragraph)
     lines = [LineEntity.from_proto(l) for l in msg.lines]
-    return ParagraphEntity(lines)
+    bbox = unwrap(BBox.from_proto(msg.bbox))
+    return ParagraphEntity(lines, bbox)
 
   def to_proto(self) -> entity_pb2.Paragraph:
-    msg = entity_pb2.Paragraph()
+    msg = entity_pb2.Paragraph(bbox=self.bbox.to_proto())
     msg.lines.extend(l.to_proto() for l in self.lines)
     return msg
 
@@ -157,15 +166,17 @@ class ParagraphEntity(Entity):
 @dataclass(frozen=True)
 class TableCellEntity(Entity):
   content: List[Entity]
+  bbox: BBox
 
   @staticmethod
   def from_proto(msg: PbEntityPayloadType) -> 'TableCellEntity':
     assert isinstance(msg, entity_pb2.TableCell)
     content = [proto_to_entity(e) for e in msg.content]
-    return TableCellEntity(content)
+    bbox = unwrap(BBox.from_proto(msg.bbox))
+    return TableCellEntity(content, bbox)
 
   def to_proto(self) -> entity_pb2.TableCell:
-    msg = entity_pb2.TableCell()
+    msg = entity_pb2.TableCell(bbox=self.bbox.to_proto())
     msg.content.extend(entity_to_proto(e) for e in self.content)
     return msg
 
@@ -178,15 +189,17 @@ class TableCellEntity(Entity):
 @dataclass(frozen=True)
 class TableRowEntity(Entity):
   cells: List[TableCellEntity]
+  bbox: BBox
 
   @staticmethod
   def from_proto(msg: PbEntityPayloadType) -> 'TableRowEntity':
     assert isinstance(msg, entity_pb2.TableRow)
     cells = [TableCellEntity.from_proto(c) for c in msg.cells]
-    return TableRowEntity(cells)
+    bbox = unwrap(BBox.from_proto(msg.bbox))
+    return TableRowEntity(cells, bbox)
 
   def to_proto(self) -> entity_pb2.TableRow:
-    msg = entity_pb2.TableRow()
+    msg = entity_pb2.TableRow(bbox=self.bbox.to_proto())
     msg.cells.extend(c.to_proto() for c in self.cells)
     return msg
 
@@ -199,15 +212,17 @@ class TableRowEntity(Entity):
 @dataclass(frozen=True)
 class TableEntity(Entity):
   rows: List[TableRowEntity]
+  bbox: BBox
 
   @staticmethod
   def from_proto(msg: PbEntityPayloadType) -> 'TableEntity':
     assert isinstance(msg, entity_pb2.Table)
     rows = [TableRowEntity.from_proto(r) for r in msg.rows]
-    return TableEntity(rows)
+    bbox = unwrap(BBox.from_proto(msg.bbox))
+    return TableEntity(rows, bbox)
 
   def to_proto(self) -> entity_pb2.Table:
-    msg = entity_pb2.Table()
+    msg = entity_pb2.Table(bbox=self.bbox.to_proto())
     msg.rows.extend(r.to_proto() for r in self.rows)
     return msg
 
@@ -219,22 +234,23 @@ class TableEntity(Entity):
 
 @dataclass(frozen=True)
 class TokenEntity(Entity):
-  span: List[OcrWordEntity]
+  span: List[WordEntity]
+  bbox: BBox
 
   @staticmethod
   def from_proto(msg: PbEntityPayloadType) -> 'TokenEntity':
     assert isinstance(msg, entity_pb2.Token)
-    span = [OcrWordEntity(InputWord.from_proto(w)) for w in msg.span]
-    return TokenEntity(span)
+    span = [WordEntity.from_proto(w) for w in msg.span]
+    bbox = unwrap(BBox.from_proto(msg.bbox))
+    return TokenEntity(span, bbox)
 
   def to_proto(self) -> entity_pb2.Token:
-    msg = entity_pb2.Token()
-    input_words = (s.word for s in self.span)
-    msg.span.extend(s.to_proto() for s in input_words)
+    msg = entity_pb2.Token(bbox=self.bbox.to_proto())
+    msg.span.extend(s.to_proto() for s in self.span)
     return msg
 
   @property
-  def children(self) -> Iterable[OcrWordEntity]:
+  def children(self) -> Iterable[WordEntity]:
     """ A TokenEntity's children are its span of OcrWordEntities. """
     yield from self.span
 
@@ -242,15 +258,17 @@ class TokenEntity(Entity):
 @dataclass(frozen=True)
 class PhraseEntity(Entity):
   words: List[TokenEntity]
+  bbox: BBox
 
   @staticmethod
   def from_proto(msg: PbEntityPayloadType) -> 'PhraseEntity':
     assert isinstance(msg, entity_pb2.Phrase)
     words = [TokenEntity.from_proto(t) for t in msg.words]
-    return PhraseEntity(words)
+    bbox = unwrap(BBox.from_proto(msg.bbox))
+    return PhraseEntity(words, bbox)
 
   def to_proto(self) -> entity_pb2.Phrase:
-    msg = entity_pb2.Phrase()
+    msg = entity_pb2.Phrase(bbox=self.bbox.to_proto())
     msg.words.extend(w.to_proto() for w in self.words)
     return msg
 
@@ -263,19 +281,21 @@ class PhraseEntity(Entity):
 @dataclass(frozen=True)
 class NumberEntity(Entity):
   token: TokenEntity
+  bbox: BBox
   value: Optional[float]
 
   @staticmethod
   def from_proto(msg: PbEntityPayloadType) -> 'NumberEntity':
     assert isinstance(msg, entity_pb2.Number)
     token = TokenEntity.from_proto(msg.token)
+    bbox = unwrap(BBox.from_proto(msg.bbox))
     value = None
     if msg.HasField('value'):
       value = msg.value
-    return NumberEntity(token, value)
+    return NumberEntity(token, bbox, value)
 
   def to_proto(self) -> entity_pb2.Number:
-    msg = entity_pb2.Number()
+    msg = entity_pb2.Number(bbox=self.bbox.to_proto())
     msg.token.CopyFrom(self.token.to_proto())
     if self.value is not None:
       msg.value = self.value
@@ -290,19 +310,21 @@ class NumberEntity(Entity):
 @dataclass(frozen=True)
 class IntegerEntity(Entity):
   token: TokenEntity
+  bbox: BBox
   value: Optional[int]
 
   @staticmethod
   def from_proto(msg: PbEntityPayloadType) -> 'IntegerEntity':
     assert isinstance(msg, entity_pb2.Integer)
     token = TokenEntity.from_proto(msg.token)
+    bbox = unwrap(BBox.from_proto(msg.bbox))
     value = None
     if msg.HasField('value'):
       value = msg.value
-    return IntegerEntity(token, value)
+    return IntegerEntity(token, bbox, value)
 
   def to_proto(self) -> entity_pb2.Integer:
-    msg = entity_pb2.Integer()
+    msg = entity_pb2.Integer(bbox=self.bbox.to_proto())
     msg.token.CopyFrom(self.token.to_proto())
     if self.value is not None:
       msg.value = self.value
@@ -317,19 +339,21 @@ class IntegerEntity(Entity):
 @dataclass(frozen=True)
 class DateEntity(Entity):
   token: TokenEntity
+  bbox: BBox
   value: Optional[str]
 
   @staticmethod
   def from_proto(msg: PbEntityPayloadType) -> 'DateEntity':
     assert isinstance(msg, entity_pb2.Date)
     token = TokenEntity.from_proto(msg.token)
+    bbox = unwrap(BBox.from_proto(msg.bbox))
     value = None
     if msg.HasField('value'):
       value = msg.value
-    return DateEntity(token, value)
+    return DateEntity(token, bbox, value)
 
   def to_proto(self) -> entity_pb2.Date:
-    msg = entity_pb2.Date()
+    msg = entity_pb2.Date(bbox=self.bbox.to_proto())
     msg.token.CopyFrom(self.token.to_proto())
     if self.value is not None:
       msg.value = self.value
@@ -344,19 +368,21 @@ class DateEntity(Entity):
 @dataclass(frozen=True)
 class TimeEntity(Entity):
   token: TokenEntity
+  bbox: BBox
   value: Optional[int]
 
   @staticmethod
   def from_proto(msg: PbEntityPayloadType) -> 'TimeEntity':
     assert isinstance(msg, entity_pb2.Time)
     token = TokenEntity.from_proto(msg.token)
+    bbox = unwrap(BBox.from_proto(msg.bbox))
     value = None
     if msg.HasField('value'):
       value = msg.value
-    return TimeEntity(token, value)
+    return TimeEntity(token, bbox, value)
 
   def to_proto(self) -> entity_pb2.Time:
-    msg = entity_pb2.Time()
+    msg = entity_pb2.Time(bbox=self.bbox.to_proto())
     msg.token.CopyFrom(self.token.to_proto())
     if self.value is not None:
       msg.value = self.value
@@ -371,6 +397,7 @@ class TimeEntity(Entity):
 @dataclass(frozen=True)
 class CurrencyEntity(Entity):
   token: TokenEntity
+  bbox: BBox
   # TODO: wrap FixedDecimal
   value: Optional[Currency_pb2.FixedDecimal]
   units: Optional[str]
@@ -379,16 +406,17 @@ class CurrencyEntity(Entity):
   def from_proto(msg: PbEntityPayloadType) -> 'CurrencyEntity':
     assert isinstance(msg, entity_pb2.Currency)
     token = TokenEntity.from_proto(msg.token)
+    bbox = unwrap(BBox.from_proto(msg.bbox))
     units = None
     if msg.HasField('units'):
       units = msg.units
     value = None
     if msg.HasField('value'):
       value = msg.value
-    return CurrencyEntity(token, value, units)
+    return CurrencyEntity(token, bbox, value, units)
 
   def to_proto(self) -> entity_pb2.Currency:
-    msg = entity_pb2.Currency()
+    msg = entity_pb2.Currency(bbox=self.bbox.to_proto())
     msg.token.CopyFrom(self.token.to_proto())
     if self.value is not None:
       msg.value.CopyFrom(self.value)
@@ -405,19 +433,21 @@ class CurrencyEntity(Entity):
 @dataclass(frozen=True)
 class NameEntity(Entity):
   name_parts: PhraseEntity
+  bbox: BBox
   value: Optional[str]
 
   @staticmethod
   def from_proto(msg: PbEntityPayloadType) -> 'NameEntity':
     assert isinstance(msg, entity_pb2.Name)
     name_parts = PhraseEntity.from_proto(msg.name_parts)
+    bbox = unwrap(BBox.from_proto(msg.bbox))
     value = None
     if msg.HasField('value'):
       value = msg.value
-    return NameEntity(name_parts, value)
+    return NameEntity(name_parts, bbox, value)
 
   def to_proto(self) -> entity_pb2.Name:
-    msg = entity_pb2.Name()
+    msg = entity_pb2.Name(bbox=self.bbox.to_proto())
     msg.name_parts.CopyFrom(self.name_parts.to_proto())
     if self.value is not None:
       msg.value = self.value
@@ -432,19 +462,21 @@ class NameEntity(Entity):
 @dataclass(frozen=True)
 class AddressEntity(Entity):
   lines: List[PhraseEntity]
+  bbox: BBox
   value: Optional[str]
 
   @staticmethod
   def from_proto(msg: PbEntityPayloadType) -> 'AddressEntity':
     assert isinstance(msg, entity_pb2.Address)
     lines = [PhraseEntity.from_proto(l) for l in msg.lines]
+    bbox = unwrap(BBox.from_proto(msg.bbox))
     value = None
     if msg.HasField('value'):
       value = msg.value
-    return AddressEntity(lines, value)
+    return AddressEntity(lines, bbox, value)
 
   def to_proto(self) -> entity_pb2.Address:
-    msg = entity_pb2.Address()
+    msg = entity_pb2.Address(bbox=self.bbox.to_proto())
     msg.lines.extend(l.to_proto() for l in self.lines)
     if self.value is not None:
       msg.value = self.value
@@ -459,19 +491,21 @@ class AddressEntity(Entity):
 @dataclass(frozen=True)
 class ClusterEntity(Entity):
   token_span: PhraseEntity
+  bbox: BBox
   label: Optional[str]
 
   @staticmethod
   def from_proto(msg: PbEntityPayloadType) -> 'ClusterEntity':
     assert isinstance(msg, entity_pb2.Cluster)
     token_span = PhraseEntity.from_proto(msg.token_span)
+    bbox = unwrap(BBox.from_proto(msg.bbox))
     label = None
     if msg.HasField('label'):
       label = msg.label
-    return ClusterEntity(token_span, label)
+    return ClusterEntity(token_span, bbox, label)
 
   def to_proto(self) -> entity_pb2.Cluster:
-    msg = entity_pb2.Cluster()
+    msg = entity_pb2.Cluster(bbox=self.bbox.to_proto())
     msg.token_span.CopyFrom(self.token_span.to_proto())
     if self.label is not None:
       msg.label = self.label
@@ -513,8 +547,8 @@ def proto_to_entity(
                     cased in this function.
   """
   payload_type = msg.WhichOneof('payload')
-  if payload_type == 'ocr_word':
-    return OcrWordEntity.from_proto(msg.ocr_word)
+  if payload_type == 'word':
+    return WordEntity.from_proto(msg.word)
   elif payload_type == 'line':
     return LineEntity.from_proto(msg.line)
   elif payload_type == 'paragraph':
@@ -573,8 +607,8 @@ def entity_to_proto(entity: Entity) -> entity_pb2.Entity:
                     cased in this function.
   """
   payload = entity.to_proto()
-  if isinstance(payload, entity_pb2.OcrWord):
-    return entity_pb2.Entity(ocr_word=payload)
+  if isinstance(payload, entity_pb2.Word):
+    return entity_pb2.Entity(word=payload)
   elif isinstance(payload, entity_pb2.Line):
     return entity_pb2.Entity(line=payload)
   elif isinstance(payload, entity_pb2.Paragraph):

--- a/py/foundation/typing_utils.py
+++ b/py/foundation/typing_utils.py
@@ -1,4 +1,4 @@
-from typing import NoReturn
+from typing import NoReturn, Optional, TypeVar
 
 
 def assert_exhaustive(x: NoReturn) -> NoReturn:
@@ -21,3 +21,14 @@ def assert_exhaustive(x: NoReturn) -> NoReturn:
         assert_exhaustive(x)  # mypy will catch this statically
   """
   raise AssertionError(f'Unhandled type: {type(x).__name__}')
+
+T = TypeVar('T')
+def unwrap(x: Optional[T]) -> T:
+  """ Non-defensively use the value inside an Optional.
+
+  Raises:
+    RuntimeError: If x is None
+  """
+  if x is None:
+    raise RuntimeError('Called unwrap() on a None value')
+  return x

--- a/unit_tests/test_entity_serialization.py
+++ b/unit_tests/test_entity_serialization.py
@@ -1,42 +1,39 @@
+from itertools import chain
 from typing import Iterable
 from unittest import TestCase
 
-from foundation.entity import (
-  OcrWordEntity, LineEntity, ParagraphEntity,
-  TableCellEntity, TableRowEntity, TableEntity,
-  TokenEntity, PhraseEntity, NumberEntity, IntegerEntity,
-  DateEntity, TimeEntity, CurrencyEntity, NameEntity,
-  AddressEntity, ClusterEntity
-)
+from foundation.entity import (Word, Line, Paragraph, TableCell, TableRow,
+                               Table, Token, Phrase, Number, Integer, Date,
+                               Time, Currency, Name, Address, Cluster)
 from foundation.geometry import BBox, Point
 from foundation.ocr import InputWord
 from foundation.protos.doc import entity_pb2
 from foundation.protos.ocr import types_pb2
+from foundation.typing_utils import unwrap
 
 
-def _input_word(text: str, spanning: Iterable[Point]) -> InputWord:
-  return InputWord(BBox.spanning(spanning), 'hello', None, None, None)
-
-
-class TestOcrWordEntity(TestCase):
-
-  def test_x_proto(self) -> None:
-    input_word = _input_word('hello', (Point(0,0), Point(5, 1)))
-    w = OcrWordEntity(input_word)
-    pb = w.to_proto()
-
-    assert w == OcrWordEntity.from_proto(pb)
-
-
-class TestLineEntity(TestCase):
+class TestWord(TestCase):
 
   def test_to_proto(self) -> None:
-    w1 = OcrWordEntity(_input_word('hello', (Point(0,0), Point(5, 1))))
-    w2 = OcrWordEntity(_input_word('world', (Point(6, 0), Point(11, 1))))
+    bbox = unwrap(BBox.spanning((Point(0, 0), Point(5, 1))))
+    w = Word('hello', bbox)
+    pb = w.to_proto()
 
-    line = LineEntity([w1, w2])
+    assert w == Word.from_proto(pb)
+
+
+class TestLine(TestCase):
+
+  def test_to_proto(self) -> None:
+    w1 = Word('hello', unwrap(BBox.spanning((Point(0, 0), Point(5, 1)))))
+    w2 = Word('world', unwrap(BBox.spanning((Point(6, 0), Point(11, 1)))))
+    words = [w1, w2]
+    bbox = unwrap(BBox.spanning(chain.from_iterable([w.bbox.corners() for w in words])))
+
+    line = Line(words, bbox)
     pb = line.to_proto()
 
-    assert line == LineEntity.from_proto(pb)
+    assert line == Line.from_proto(pb)
+
 
 # TODO: Full test coverage. Let's finish stabilizing Entity types first.

--- a/unit_tests/test_entity_serialization.py
+++ b/unit_tests/test_entity_serialization.py
@@ -3,8 +3,8 @@ from typing import Iterable
 from unittest import TestCase
 
 from foundation.entity import (Word, Line, Paragraph, TableCell, TableRow,
-                               Table, Token, Phrase, Number, Integer, Date,
-                               Time, Currency, Name, Address, Cluster)
+                               Table, Number, Integer, Date, Time, Currency,
+                               PersonName, Address, Cluster)
 from foundation.geometry import BBox, Point
 from foundation.ocr import InputWord
 from foundation.protos.doc import entity_pb2
@@ -28,7 +28,8 @@ class TestLine(TestCase):
     w1 = Word('hello', unwrap(BBox.spanning((Point(0, 0), Point(5, 1)))))
     w2 = Word('world', unwrap(BBox.spanning((Point(6, 0), Point(11, 1)))))
     words = [w1, w2]
-    bbox = unwrap(BBox.spanning(chain.from_iterable([w.bbox.corners() for w in words])))
+    bbox = unwrap(
+        BBox.spanning(chain.from_iterable([w.bbox.corners() for w in words])))
 
     line = Line(words, bbox)
     pb = line.to_proto()


### PR DESCRIPTION
Every Entity should have a BBox.

Renames `OcrWordEntity` to `WordEntity`. Would it also make sense to just get rid of `TokenEntity` and `PhraseEntity`? We can probably get by with just `ClusterEntity` and `LineEntity`, along with the other semantic entities.

We also don't need to store raw ocr word info. We could make that an optional property of `WordEntity` (previously `OcrWordEntity`), or just not have it at all?