### PR TITLE
BBox union method, Word.from_inputword constructor

### DIFF
--- a/py/foundation/entity.py
+++ b/py/foundation/entity.py
@@ -23,10 +23,8 @@ PbEntityPayloadType = Union[entity_pb2.Word, entity_pb2.Line,
                             entity_pb2.Address, entity_pb2.Cluster,
                             entity_pb2.GenericEntity]
 
-E = TypeVar('E', bound='Entity')
 
-
-class Entity(abc.ABC, Generic[E]):
+class Entity(abc.ABC):
   bbox: BBox
 
   @staticmethod
@@ -83,6 +81,13 @@ class Word(Entity):
   origin: Optional[InputWord] = None
 
   @staticmethod
+  def from_inputword(origin: InputWord) -> Optional['Word']:
+    text = origin.text
+    if text is None:
+      return None
+    return Word(text, origin.bounding_box, origin)
+
+  @staticmethod
   def from_proto(msg: PbEntityPayloadType) -> 'Word':
     assert isinstance(msg, entity_pb2.Word)
     text = msg.text
@@ -99,7 +104,7 @@ class Word(Entity):
     return msg
 
   @property
-  def children(self) -> Iterable[E]:
+  def children(self) -> Iterable[Entity]:
     """ Word has no children. """
     yield from []
 

--- a/py/foundation/geometry.py
+++ b/py/foundation/geometry.py
@@ -238,6 +238,13 @@ class BBox:
     return BBox(ix, iy)
 
   @staticmethod
+  def union(bs: Iterable['BBox']) -> 'BBox':
+    b = BBox.spanning(
+      chain.from_iterable([b.corners() for b in bs]))
+    assert b is not None
+    return b
+
+  @staticmethod
   def distance(b1: 'BBox', b2: 'BBox') -> float:
     ix = Interval(min(b1.ix.a, b2.ix.a), max(b1.ix.b, b2.ix.b))
     iy = Interval(min(b1.iy.a, b2.iy.a), max(b1.iy.b, b2.iy.b))

--- a/unit_tests/test_entity_serialization.py
+++ b/unit_tests/test_entity_serialization.py
@@ -27,13 +27,11 @@ class TestLine(TestCase):
   def test_to_proto(self) -> None:
     w1 = Word('hello', unwrap(BBox.spanning((Point(0, 0), Point(5, 1)))))
     w2 = Word('world', unwrap(BBox.spanning((Point(6, 0), Point(11, 1)))))
+
     words = [w1, w2]
-    bbox = unwrap(
-        BBox.spanning(chain.from_iterable([w.bbox.corners() for w in words])))
+    line = Line(words, BBox.union(w.bbox for w in words))
 
-    line = Line(words, bbox)
     pb = line.to_proto()
-
     assert line == Line.from_proto(pb)
 
 


### PR DESCRIPTION
Aimed at making Entity construction easier, since many Entities' bbox will be the union of their children.

It should be a one-to-two-liner to construct an Entity, e.g.:
```
words: List[Entity]
line = Line(words, BBox.union(w.bbox for w in words))
```

**Why not add a small method/utility function for constructing entities?***

Mostly, it feels simple enough to just take the union of BBoxes explicitly. But also, adding such a function comes with a few caveats:

1. Every Entity has a different idea of what its children are, and how it relates to its children. This means probably writing a method/utility function for each variant.
2. Adding a method to each Entity would still mostly just be rewriting some form of `EntityName(children, BBox.union(e.bbox for e in children))`. The effect would still require a call to e.g. `EntityName.from_children(children)` -- we're saving maybe a few 10s of chars in a line.
3. A general `Entity.bounding_box_union(Es: Iterable[Entity]) -> BBox` would not necessarily be defined -- what if every entity in `Es` is on a different page/doc/coordinate space? And it doesn't feel any less verbose to use.

@vontell you may have a different take on this, lmk what you think.