### PR TITLE
Entities have text

### DIFF
--- a/protos/foundation/protos/ocr/types.proto
+++ b/protos/foundation/protos/ocr/types.proto
@@ -13,7 +13,7 @@ import "foundation/protos/geometry.proto";
 */
 message InputWord {
 	required geometry.BBox bounding_box = 1;
-	optional string text = 2;
+	required string text = 2;
 
 	optional WordConfidence confidence = 6;
 	// TODO: if line_height/word_width are taken from the BBox info,

--- a/py/foundation/entity.py
+++ b/py/foundation/entity.py
@@ -105,12 +105,12 @@ class Page(Entity):
 
 @dataclass(frozen=True)
 class Word(Entity):
-  _text: Optional[str]
+  _text: str
   bbox: BBox
   origin: Optional[InputWord] = None
 
   @staticmethod
-  def from_inputword(origin: InputWord) -> Optional['Word']:
+  def from_inputword(origin: InputWord) -> 'Word':
     return Word(origin.text, origin.bounding_box, origin)
 
   @staticmethod

--- a/py/foundation/ocr.py
+++ b/py/foundation/ocr.py
@@ -64,7 +64,7 @@ class WordConfidence:
 @dataclass(frozen=True)
 class InputWord:
   bounding_box: BBox
-  text: Optional[str]
+  text: str
   confidence: Optional[WordConfidence]
 
   char_width: Optional[float]
@@ -75,9 +75,7 @@ class InputWord:
     bbox = BBox.from_proto(msg.bounding_box)
     assert bbox is not None  # TODO: how do we handle this?
 
-    text = None
-    if msg.HasField('text'):
-      text = msg.text
+    text = msg.text
     confidence = None
     if msg.HasField('confidence'):
       confidence = WordConfidence.from_proto(msg.confidence)
@@ -87,6 +85,7 @@ class InputWord:
     rotation_angle = None
     if msg.HasField('rotation_angle'):
       rotation_angle = msg.rotation_angle
+
     return InputWord(bbox, text, confidence, char_width, rotation_angle)
 
   def to_proto(self) -> types_pb2.InputWord:

--- a/py/foundation/protos/ocr/types_pb2.py
+++ b/py/foundation/protos/ocr/types_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto2',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n!foundation/protos/ocr/types.proto\x12\x03ocr\x1a foundation/protos/geometry.proto\"\xbd\x01\n\tInputWord\x12$\n\x0c\x62ounding_box\x18\x01 \x02(\x0b\x32\x0e.geometry.BBox\x12\x0c\n\x04text\x18\x02 \x01(\t\x12\'\n\nconfidence\x18\x06 \x01(\x0b\x32\x13.ocr.WordConfidence\x12\x13\n\x0bline_height\x18\x07 \x01(\x02\x12\x12\n\nword_width\x18\x08 \x01(\x02\x12\x12\n\nchar_width\x18\t \x01(\x02\x12\x16\n\x0erotation_angle\x18\n \x01(\x02\"p\n\x0eWordConfidence\x12\x17\n\x0fword_confidence\x18\x01 \x01(\x01\x12\x16\n\x0elow_confidence\x18\x02 \x01(\x08\x12-\n\x10\x63har_confidences\x18\x03 \x03(\x0b\x32\x13.ocr.CharConfidence\"4\n\x0e\x43harConfidence\x12\x12\n\npercentage\x18\x01 \x02(\x01\x12\x0e\n\x06unsure\x18\x02 \x01(\x08'
+  serialized_pb=b'\n!foundation/protos/ocr/types.proto\x12\x03ocr\x1a foundation/protos/geometry.proto\"\xbd\x01\n\tInputWord\x12$\n\x0c\x62ounding_box\x18\x01 \x02(\x0b\x32\x0e.geometry.BBox\x12\x0c\n\x04text\x18\x02 \x02(\t\x12\'\n\nconfidence\x18\x06 \x01(\x0b\x32\x13.ocr.WordConfidence\x12\x13\n\x0bline_height\x18\x07 \x01(\x02\x12\x12\n\nword_width\x18\x08 \x01(\x02\x12\x12\n\nchar_width\x18\t \x01(\x02\x12\x16\n\x0erotation_angle\x18\n \x01(\x02\"p\n\x0eWordConfidence\x12\x17\n\x0fword_confidence\x18\x01 \x01(\x01\x12\x16\n\x0elow_confidence\x18\x02 \x01(\x08\x12-\n\x10\x63har_confidences\x18\x03 \x03(\x0b\x32\x13.ocr.CharConfidence\"4\n\x0e\x43harConfidence\x12\x12\n\npercentage\x18\x01 \x02(\x01\x12\x0e\n\x06unsure\x18\x02 \x01(\x08'
   ,
   dependencies=[foundation_dot_protos_dot_geometry__pb2.DESCRIPTOR,])
 
@@ -44,7 +44,7 @@ _INPUTWORD = _descriptor.Descriptor(
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
       name='text', full_name='ocr.InputWord.text', index=1,
-      number=2, type=9, cpp_type=9, label=1,
+      number=2, type=9, cpp_type=9, label=2,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,

--- a/unit_tests/test_entity.py
+++ b/unit_tests/test_entity.py
@@ -34,5 +34,13 @@ class TestLine(TestCase):
     pb = line.to_proto()
     assert line == Line.from_proto(pb)
 
+  def test_text(self) -> None:
+    w1 = Word('hello', unwrap(BBox.spanning((Point(0, 0), Point(5, 1)))))
+    w2 = Word('world', unwrap(BBox.spanning((Point(6, 0), Point(11, 1)))))
+
+    words = (w1, w2)
+    line = Line(words, unwrap(BBox.union(w.bbox for w in words)))
+
+    assert line.text() == 'hello world'
 
 # TODO: Full test coverage. Let's finish stabilizing Entity types first.


### PR DESCRIPTION
Entities should handle logic for representing themselves as text, when appropriate.

* Adds a `text: (Self) -> Optional[str]` method on `Entity` to be implemented by subclasses.
* Changes `InputWord` to require a `text` field, since we can assume any WordPolyDict has `Some(text)` (i.e. text would never be `None`).